### PR TITLE
Fix flaky tpcds/etl/q39 query

### DIFF
--- a/src/main/resources/queries/tpcds/etl/control/sf100/q39.sql
+++ b/src/main/resources/queries/tpcds/etl/control/sf100/q39.sql
@@ -2,5 +2,5 @@ SELECT *
 FROM
 (
   VALUES
-    (X'e0 3a 3d cf 3b b7 8c 01', X'e3 c0 25 4f 36 f7 ff 59', X'60 95 20 5b 36 d2 c7 47', X'2a bc c6 5b 1f 18 71 f3', X'14 4e f8 19 eb 7b fe 8d', X'00 ca 55 e0 15 9a b0 7f', X'bb 32 2d 0d e3 70 68 37', X'ca f8 99 ba 1e 60 ee 05')
+    (X'e0 3a 3d cf 3b b7 8c 01', X'e3 c0 25 4f 36 f7 ff 59', X'60 95 20 5b 36 d2 c7 47', X'2a bc c6 5b 1f 18 71 f3', X'00 ca 55 e0 15 9a b0 7f', X'bb 32 2d 0d e3 70 68 37')
 )

--- a/src/main/resources/queries/tpcds/etl/control/sf10000/q39.sql
+++ b/src/main/resources/queries/tpcds/etl/control/sf10000/q39.sql
@@ -2,5 +2,5 @@ SELECT *
 FROM
 (
   VALUES
-    (X'00 2b 2f a7 ed e6 ae dc', X'4f ba d3 f6 e7 37 3c bb', X'70 c2 a9 8a b7 82 4c f8', X'1d a3 ef 0b a3 0e 4a db', X'b6 d6 37 e6 28 8c 63 3c', X'00 a9 00 98 06 f0 af 73', X'9c 4f 0a 24 4b 1e 54 9d', X'41 e3 4d aa 81 24 cc f7')
+    (X'00 2b 2f a7 ed e6 ae dc', X'4f ba d3 f6 e7 37 3c bb', X'70 c2 a9 8a b7 82 4c f8', X'1d a3 ef 0b a3 0e 4a db', X'00 a9 00 98 06 f0 af 73', X'9c 4f 0a 24 4b 1e 54 9d')
 )

--- a/src/main/resources/queries/tpcds/etl/control/tiny/q39.sql
+++ b/src/main/resources/queries/tpcds/etl/control/tiny/q39.sql
@@ -2,5 +2,5 @@ SELECT *
 FROM
 (
   VALUES
-    (X'70 ac d1 17 64 16 75 3e', X'01 f6 a6 a7 59 54 26 b5', X'70 ac d1 17 64 16 75 3e', X'4b 98 e7 04 cb 0e b3 f1', X'6e 9c fc 40 9e 32 ee 0b', X'00 09 50 55 fc 37 45 05', X'dd aa ca 8e ee d3 da 43', X'e6 58 eb cb 12 d7 d6 5a')
+    (X'70 ac d1 17 64 16 75 3e', X'01 f6 a6 a7 59 54 26 b5', X'70 ac d1 17 64 16 75 3e', X'4b 98 e7 04 cb 0e b3 f1', X'00 09 50 55 fc 37 45 05', X'dd aa ca 8e ee d3 da 43')
 )

--- a/src/main/resources/queries/tpcds/etl/q39.sql
+++ b/src/main/resources/queries/tpcds/etl/q39.sql
@@ -35,10 +35,8 @@ SELECT
 , "inv1"."i_item_sk"
 , "inv1"."d_moy" d_moy_1
 , "inv1"."mean" mean_1
-, "inv1"."cov" cov_1
 , "inv2"."d_moy" d_moy_2
 , "inv2"."mean" mean_2
-, "inv2"."cov" cov_2
 FROM
   inv inv1
 , inv inv2


### PR DESCRIPTION
Covarience introduces variability and the query becomes flaky for
larger data sets (sf10000+)